### PR TITLE
Added coin selection for automatic settlements

### DIFF
--- a/NBXplorer.Tests/CoinSelection/SelectionStrategies/SmallestFirstTests.cs
+++ b/NBXplorer.Tests/CoinSelection/SelectionStrategies/SmallestFirstTests.cs
@@ -2,10 +2,13 @@ using System.Collections.Generic;
 using System.Linq;
 using NBitcoin;
 using NBXplorer;
+using NBXplorer.CoinSelection.SelectionStrategies;
 using NBXplorer.Models;
 using Xunit;
 
-public class CoinSelectionHelpersTests
+namespace NBXplorer.Tests.CoinSelection.SelectionStrategies;
+
+public class SmallestFirstTests
 {
 	public static List<IMoney> GetValues(List<UTXO> utxos)
 	{
@@ -21,9 +24,10 @@ public class CoinSelectionHelpersTests
 		// Arrange
 		int limit = 3;
 		long amount = 10;
+		var coinSelector = new SmallestFirst();
 
 		// Act
-		var result = CoinSelectionHelpers.SelectCoins(new List<UTXO>(), limit, amount);
+		var result = coinSelector.SelectCoins(new List<UTXO>(), limit, amount);
 
 		// Assert
 		Assert.Empty(result);
@@ -39,9 +43,10 @@ public class CoinSelectionHelpersTests
 		};
 		int limit = 3;
 		long amount = 9;
+		var coinSelector = new SmallestFirst();
 
 		// Act
-		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount);
+		var result = coinSelector.SelectCoins(utxos, limit, amount);
 
 		// Assert
 		Assert.Equal(new[] { new Money(10) }, GetValues(result));
@@ -57,9 +62,10 @@ public class CoinSelectionHelpersTests
 		};
 		int limit = 3;
 		long amount = 7;
+		var coinSelector = new SmallestFirst();
 
 		// Act
-		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount);
+		var result = coinSelector.SelectCoins(utxos, limit, amount);
 
 		// Assert
 		Assert.Equal(new[] { new Money(8) }, GetValues(result));
@@ -75,9 +81,10 @@ public class CoinSelectionHelpersTests
 		};
 		int limit = 3;
 		long amount = 9;
+		var coinSelector = new SmallestFirst();
 
 		// Act
-		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount);
+		var result = coinSelector.SelectCoins(utxos, limit, amount);
 
 		// Assert
 		Assert.Empty(GetValues(result));
@@ -93,9 +100,10 @@ public class CoinSelectionHelpersTests
 		};
 		int limit = 3;
 		long amount = 9;
+		var coinSelector = new SmallestFirst();
 
 		// Act
-		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount);
+		var result = coinSelector.SelectCoins(utxos, limit, amount);
 
 		// Assert
 		Assert.Empty(GetValues(result));
@@ -117,9 +125,10 @@ public class CoinSelectionHelpersTests
 		};
 		int limit = 3;
 		long amount = 9;
+		var coinSelector = new SmallestFirst();
 
 		// Act
-		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount);
+		var result = coinSelector.SelectCoins(utxos, limit, amount);
 
 		// Assert
 		Assert.Equal(new[] { new Money(1), new Money(2), new Money(6) }, GetValues(result));
@@ -139,9 +148,10 @@ public class CoinSelectionHelpersTests
 		};
 		int limit = 3;
 		long amount = 9;
+		var coinSelector = new SmallestFirst();
 
 		// Act
-		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount);
+		var result = coinSelector.SelectCoins(utxos, limit, amount);
 
 		// Assert
 		Assert.Equal(new[] { new Money(1), new Money(5), new Money(5) }, GetValues(result));
@@ -162,9 +172,10 @@ public class CoinSelectionHelpersTests
 		};
 		int limit = 3;
 		long amount = 12;
+		var coinSelector = new SmallestFirst();
 
 		// Act
-		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount);
+		var result = coinSelector.SelectCoins(utxos, limit, amount);
 
 		// Assert
 		Assert.Equal(new[] { new Money(5), new Money(5), new Money(5) }, GetValues(result));
@@ -186,9 +197,10 @@ public class CoinSelectionHelpersTests
 		};
 		int limit = 3;
 		long amount = 20;
+		var coinSelector = new SmallestFirst();
 
 		// Act
-		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount);
+		var result = coinSelector.SelectCoins(utxos, limit, amount);
 
 		// Assert
 		Assert.Equal(new[] { new Money(5), new Money(5), new Money(10) }, GetValues(result));
@@ -210,9 +222,10 @@ public class CoinSelectionHelpersTests
 		};
 		int limit = 3;
 		long amount = 9;
+		var coinSelector = new SmallestFirst();
 
 		// Act
-		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount);
+		var result = coinSelector.SelectCoins(utxos, limit, amount);
 
 		// Assert
 		Assert.Equal(new[] { new Money(6), new Money(3) }, GetValues(result));
@@ -232,9 +245,10 @@ public class CoinSelectionHelpersTests
 		};
 		int limit = 3;
 		long amount = 9;
+		var coinSelector = new SmallestFirst();
 
 		// Act
-		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount);
+		var result = coinSelector.SelectCoins(utxos, limit, amount);
 
 		// Assert
 		Assert.Equal(new[] { new Money(5), new Money(5) }, GetValues(result));
@@ -254,9 +268,10 @@ public class CoinSelectionHelpersTests
 		};
 		int limit = 3;
 		long amount = 14;
+		var coinSelector = new SmallestFirst();
 
 		// Act
-		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount);
+		var result = coinSelector.SelectCoins(utxos, limit, amount);
 
 		// Assert
 		Assert.Equal(new[] { new Money(5), new Money(6), new Money(4) }, GetValues(result));

--- a/NBXplorer.Tests/CoinSelection/SelectionStrategies/UpToAmountTests.cs
+++ b/NBXplorer.Tests/CoinSelection/SelectionStrategies/UpToAmountTests.cs
@@ -1,0 +1,96 @@
+using System.Collections.Generic;
+using System.Linq;
+using NBitcoin;
+using NBXplorer;
+using NBXplorer.CoinSelection.SelectionStrategies;
+using NBXplorer.Models;
+using Xunit;
+
+namespace NBXplorer.Tests.CoinSelection.SelectionStrategies;
+
+public class UpToAmountTests
+{
+	public static List<IMoney> GetValues(List<UTXO> utxos)
+	{
+		return utxos.Select(u => u.Value).ToList();
+	}
+
+	/// <summary>
+	/// General tests for SelectCoins
+	/// </summary>
+	[Fact]
+	public void SelectCoins_ShouldReturnEmptyList_WhenUTXOsListIsEmpty()
+	{
+		// Arrange
+		int limit = 3;
+		long amount = 10;
+		var coinSelector = new UpToAmount();
+
+		// Act
+		var result = coinSelector.SelectCoins(new List<UTXO>(), limit, amount);
+
+		// Assert
+		Assert.Empty(result);
+	}
+
+	[Fact]
+	public void SelectCoins_ShouldReturnSelectedCoins_Changeless_InsideToleranceAbove_OneUtxoCoversAll()
+	{
+		// Arrange
+		var utxos = new List<UTXO>()
+		{
+			new UTXO { Value = new Money(7) },
+			new UTXO { Value = new Money(6) },
+		};
+		int limit = 3;
+		long amount = 7;
+		var coinSelector = new UpToAmount();
+
+		// Act
+		var result = coinSelector.SelectCoins(utxos, limit, amount);
+
+		// Assert
+		Assert.Equal(new[] { new Money(7) }, GetValues(result));
+	}
+
+	[Fact]
+	public void SelectCoins_ShouldReturnSelectedCoins_Changeless_InsideToleranceAbove_OneUtxoCoversBelowTarget()
+	{
+		// Arrange
+		var utxos = new List<UTXO>()
+		{
+			new UTXO { Value = new Money(7) },
+			new UTXO { Value = new Money(6) },
+		};
+		int limit = 3;
+		long amount = 8;
+		var coinSelector = new UpToAmount();
+
+		// Act
+		var result = coinSelector.SelectCoins(utxos, limit, amount);
+
+		// Assert
+		Assert.Equal(new[] { new Money(7) }, GetValues(result));
+	}
+
+	[Fact]
+	public void SelectCoins_ShouldReturnSelectedCoins_Changeless_NoUtxoCoversTheAmount()
+	{
+		// Arrange
+		var utxos = new List<UTXO>()
+		{
+			new UTXO { Value = new Money(5) },
+			new UTXO { Value = new Money(4) },
+			new UTXO { Value = new Money(1) },
+		};
+		int limit = 3;
+		long amount = 6;
+		var coinSelector = new UpToAmount();
+
+		// Act
+		var result = coinSelector.SelectCoins(utxos, limit, amount);
+
+		// Assert
+		Assert.Equal(new[] { new Money(5), new Money(1) }, GetValues(result));
+	}
+}

--- a/NBXplorer/CoinSelection/CoinSelectionHelpers.cs
+++ b/NBXplorer/CoinSelection/CoinSelectionHelpers.cs
@@ -12,6 +12,7 @@ public static class CoinSelectionHelpers
 		switch (strategy)
 		{
 			case CoinSelectionStrategy.BiggestFirst:
+			case CoinSelectionStrategy.UpToAmount:
 				return "value DESC";
 			case CoinSelectionStrategy.ClosestToTargetFirst:
 				return $"abs(value - {target})";
@@ -20,51 +21,9 @@ public static class CoinSelectionHelpers
 				return "value ASC";
 		}
 	}
+}
 
-	public static List<UTXO> SelectCoins(List<UTXO> UTXOs, int limit, long amount)
-	{
-		if (limit == 0)
-		{
-			return UTXOs;
-		}
-
-		var utxosQueued = new Queue<UTXO>(UTXOs);
-		var targetAmount = new Money(amount);
-		var currentAmount = new Money(0);
-		var count = 0;
-		var retroCount = limit;
-
-		var selectedCoins = new List<UTXO>();
-		while (utxosQueued.Count > 0)
-		{
-			var utxo = utxosQueued.Dequeue();
-			var utxoValue = (Money)utxo.Value;
-			if (currentAmount < targetAmount)
-			{
-				if (count >= limit && currentAmount < targetAmount)
-				{
-					retroCount = retroCount <= 0 ? limit - 1 : retroCount - 1;
-					var prevUtxo = selectedCoins[retroCount];
-					currentAmount -= (Money)prevUtxo.Value;
-					selectedCoins[retroCount] = utxo;
-					currentAmount += utxoValue;
-				}
-
-				if (count < limit)
-				{
-					var newAmount = currentAmount + utxoValue;
-					selectedCoins.Add(utxo);
-					currentAmount = newAmount;
-					count++;
-				}
-			}
-		}
-
-		if (currentAmount < targetAmount)
-		{
-			selectedCoins.Clear();
-		}
-
-		return selectedCoins;
-	}
+public interface ISelectionStrategies
+{
+	public List<UTXO> SelectCoins(List<UTXO> UTXOs, int limit, long amount);
 }

--- a/NBXplorer/CoinSelection/CoinSelectionHelpers.cs
+++ b/NBXplorer/CoinSelection/CoinSelectionHelpers.cs
@@ -9,17 +9,14 @@ public static class CoinSelectionHelpers
 {
 	public static string OrderBy(CoinSelectionStrategy strategy, long target = 0)
 	{
-		switch (strategy)
+		return strategy switch
 		{
-			case CoinSelectionStrategy.BiggestFirst:
-			case CoinSelectionStrategy.UpToAmount:
-				return "value DESC";
-			case CoinSelectionStrategy.ClosestToTargetFirst:
-				return $"abs(value - {target})";
-			case CoinSelectionStrategy.SmallestFirst:
-			default:
-				return "value ASC";
-		}
+			CoinSelectionStrategy.BiggestFirst => "value DESC",
+			CoinSelectionStrategy.UpToAmount => "value DESC",
+			CoinSelectionStrategy.ClosestToTargetFirst => $"abs(value - {target})",
+			CoinSelectionStrategy.SmallestFirst => "value ASC",
+			_ => throw new ArgumentOutOfRangeException(nameof(strategy), $@"Not expected strategy value: {strategy}"),
+		};
 	}
 }
 

--- a/NBXplorer/CoinSelection/CoinSelectionStrategy.cs
+++ b/NBXplorer/CoinSelection/CoinSelectionStrategy.cs
@@ -4,5 +4,6 @@ public enum CoinSelectionStrategy
 {
 	SmallestFirst,
 	BiggestFirst,
-	ClosestToTargetFirst
+	ClosestToTargetFirst,
+	UpToAmount
 }

--- a/NBXplorer/CoinSelection/SelectionStrategies/SmallestFirst.cs
+++ b/NBXplorer/CoinSelection/SelectionStrategies/SmallestFirst.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using NBitcoin;
+using NBXplorer.Models;
+
+namespace NBXplorer.CoinSelection.SelectionStrategies;
+
+public class SmallestFirst: ISelectionStrategies
+{
+	public List<UTXO> SelectCoins(List<UTXO> UTXOs, int limit, long amount)
+	{
+		if (limit == 0)
+		{
+			return UTXOs;
+		}
+
+		var utxosQueued = new Queue<UTXO>(UTXOs);
+		var targetAmount = new Money(amount);
+		var currentAmount = new Money(0);
+		var count = 0;
+		var retroCount = limit;
+
+		var selectedCoins = new List<UTXO>();
+		while (utxosQueued.Count > 0)
+		{
+			var utxo = utxosQueued.Dequeue();
+			var utxoValue = (Money)utxo.Value;
+			if (currentAmount < targetAmount)
+			{
+				if (count >= limit && currentAmount < targetAmount)
+				{
+					retroCount = retroCount <= 0 ? limit - 1 : retroCount - 1;
+					var prevUtxo = selectedCoins[retroCount];
+					currentAmount -= (Money)prevUtxo.Value;
+					selectedCoins[retroCount] = utxo;
+					currentAmount += utxoValue;
+				}
+
+				if (count < limit)
+				{
+					var newAmount = currentAmount + utxoValue;
+					selectedCoins.Add(utxo);
+					currentAmount = newAmount;
+					count++;
+				}
+			}
+		}
+
+		if (currentAmount < targetAmount)
+		{
+			selectedCoins.Clear();
+		}
+
+		return selectedCoins;
+	}
+}

--- a/NBXplorer/CoinSelection/SelectionStrategies/UpToAmount.cs
+++ b/NBXplorer/CoinSelection/SelectionStrategies/UpToAmount.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using NBitcoin;
+using NBXplorer.Models;
+
+namespace NBXplorer.CoinSelection.SelectionStrategies;
+
+public class UpToAmount: ISelectionStrategies
+{
+	public List<UTXO> SelectCoins(List<UTXO> UTXOs, int limit, long amount)
+	{
+		if (limit == 0)
+		{
+			return UTXOs;
+		}
+
+		var utxosQueued = new Queue<UTXO>(UTXOs);
+		var targetAmount = new Money(amount);
+		var currentAmount = new Money(0);
+		var count = 0;
+
+		var selectedCoins = new List<UTXO>();
+		while (utxosQueued.Count > 0)
+		{
+			if (count > limit)
+			{
+				break;
+			}
+
+			var utxo = utxosQueued.Dequeue();
+			var utxoValue = (Money)utxo.Value;
+			var newAmount = currentAmount + utxoValue;
+			if (newAmount > targetAmount)
+			{
+				continue;
+			}
+			selectedCoins.Add(utxo);
+			currentAmount = newAmount;
+			count++;
+
+		}
+
+		return selectedCoins;
+	}
+}

--- a/NBXplorer/Controllers/CoinSelectionController.cs
+++ b/NBXplorer/Controllers/CoinSelectionController.cs
@@ -8,6 +8,7 @@ using NBXplorer.DerivationStrategy;
 using NBXplorer.ModelBinders;
 using NBXplorer.Models;
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using NBXplorer.CoinSelection.SelectionStrategies;
 
@@ -139,6 +140,9 @@ namespace NBXplorer.Controllers
 				else
 					changes.Confirmed.UTXOs.Add(u);
 			}
+
+			changes.Confirmed.UTXOs = changes.Confirmed.UTXOs.DistinctBy(x => x.Outpoint).ToList();
+			changes.Unconfirmed.UTXOs = changes.Unconfirmed.UTXOs.DistinctBy(x => x.Outpoint).ToList();
 
 			ISelectionStrategies selectionStrategy;
 			switch (strategy)

--- a/NBXplorer/Controllers/CoinSelectionController.cs
+++ b/NBXplorer/Controllers/CoinSelectionController.cs
@@ -82,7 +82,7 @@ namespace NBXplorer.Controllers
 				descriptorColumns = "ds.metadata->>'redeem' redeem, nbxv1_get_keypath(d.metadata, ds.idx) AS keypath, d.metadata->>'feature' feature";
 			}
 
-			var belowAmount = strategy == CoinSelectionStrategy.UpToAmount ? $"AND value < {amount}" : "";
+			var belowAmount = strategy == CoinSelectionStrategy.UpToAmount ? $"AND value <= {amount}" : "";
 			// Added OrderBy to the query
 			var utxos = await conn.QueryAsync<(
 				long? blk_height,

--- a/NBXplorer/Controllers/CoinSelectionController.cs
+++ b/NBXplorer/Controllers/CoinSelectionController.cs
@@ -40,6 +40,7 @@ namespace NBXplorer.Controllers
 		/// <param name="limit"></param>
 		/// <param name="closestTo"></param>
 		/// <param name="strategy"></param>
+		/// <param name="ignoreOutpoint"></param>
 		/// <returns></returns>
 		/// <exception cref="ArgumentNullException"></exception>
 		[HttpGet]
@@ -56,7 +57,8 @@ namespace NBXplorer.Controllers
 			[FromQuery(Name = "amount")] long amount,
 			[FromQuery(Name = "limit")] int limit = 0,
 			[FromQuery(Name = "closestTo")] long? closestTo = null,
-			[FromQuery(Name = "strategy")] CoinSelectionStrategy strategy = CoinSelectionStrategy.SmallestFirst)
+			[FromQuery(Name = "strategy")] CoinSelectionStrategy strategy = CoinSelectionStrategy.SmallestFirst,
+			[FromQuery(Name = "ignoreOutpoint")] string[] ignoreOutpoint = null)
 		{
 			var trackedSource = GetTrackedSource(derivationScheme, address);
 			if (trackedSource == null)
@@ -131,6 +133,8 @@ namespace NBXplorer.Controllers
 					u.Feature = Enum.Parse<DerivationFeature>(utxo.feature);
 				}
 				u.Address = utxo.address is null ? u.ScriptPubKey.GetDestinationAddress(network.NBitcoinNetwork) : BitcoinAddress.Create(utxo.address, network.NBitcoinNetwork);
+
+				if (ignoreOutpoint != null && ignoreOutpoint.Contains(u.Outpoint.ToString())) continue;
 
 				// Inverted clauses for clarity
 				if (utxo.mempool)

--- a/NBXplorer/Controllers/CoinSelectionController.cs
+++ b/NBXplorer/Controllers/CoinSelectionController.cs
@@ -9,6 +9,7 @@ using NBXplorer.ModelBinders;
 using NBXplorer.Models;
 using System;
 using System.Threading.Tasks;
+using NBXplorer.CoinSelection.SelectionStrategies;
 
 namespace NBXplorer.Controllers
 {
@@ -81,6 +82,7 @@ namespace NBXplorer.Controllers
 				descriptorColumns = "ds.metadata->>'redeem' redeem, nbxv1_get_keypath(d.metadata, ds.idx) AS keypath, d.metadata->>'feature' feature";
 			}
 
+			var belowAmount = strategy == CoinSelectionStrategy.UpToAmount ? "" : $"AND value < {amount}";
 			// Added OrderBy to the query
 			var utxos = await conn.QueryAsync<(
 				long? blk_height,
@@ -96,7 +98,7 @@ namespace NBXplorer.Controllers
 				bool input_mempool,
 				DateTime tx_seen_at)>(
 				$"SELECT blk_height, tx_id, wu.idx, value, script, {addrColumns}, {descriptorColumns}, mempool, input_mempool, seen_at " +
-				$"FROM wallets_utxos wu{descriptorJoin} WHERE code='{network.CryptoCode}' AND wallet_id='{repo.GetWalletKey(trackedSource).wid}' AND immature IS FALSE AND value > 546" +
+				$"FROM wallets_utxos wu{descriptorJoin} WHERE code='{network.CryptoCode}' AND wallet_id='{repo.GetWalletKey(trackedSource).wid}' AND immature IS FALSE AND value > 546 {belowAmount}" +
 				$"ORDER BY {CoinSelectionHelpers.OrderBy(strategy, closestTo ?? 0)}");
 			UTXOChanges changes = new UTXOChanges()
 			{
@@ -138,9 +140,23 @@ namespace NBXplorer.Controllers
 					changes.Confirmed.UTXOs.Add(u);
 			}
 
+			ISelectionStrategies selectionStrategy;
+			switch (strategy)
+			{
+				case CoinSelectionStrategy.SmallestFirst:
+					selectionStrategy = new SmallestFirst();
+					break;
+				case CoinSelectionStrategy.UpToAmount:
+					selectionStrategy = new UpToAmount();
+					break;
+				default:
+					selectionStrategy = new SmallestFirst();
+					break;
+			}
+
+			changes.Confirmed.UTXOs = selectionStrategy.SelectCoins(changes.Confirmed.UTXOs, limit, amount);
+			changes.Unconfirmed.UTXOs = selectionStrategy.SelectCoins(changes.Unconfirmed.UTXOs, limit, amount);
 			// Added the coin selection
-			changes.Confirmed.UTXOs = CoinSelectionHelpers.SelectCoins(changes.Confirmed.UTXOs, limit, amount);
-			changes.Unconfirmed.UTXOs = CoinSelectionHelpers.SelectCoins(changes.Unconfirmed.UTXOs, limit, amount);
 			return Json(changes, network.JsonSerializerSettings);
 		}
 	}

--- a/NBXplorer/Controllers/CoinSelectionController.cs
+++ b/NBXplorer/Controllers/CoinSelectionController.cs
@@ -82,7 +82,7 @@ namespace NBXplorer.Controllers
 				descriptorColumns = "ds.metadata->>'redeem' redeem, nbxv1_get_keypath(d.metadata, ds.idx) AS keypath, d.metadata->>'feature' feature";
 			}
 
-			var belowAmount = strategy == CoinSelectionStrategy.UpToAmount ? "" : $"AND value < {amount}";
+			var belowAmount = strategy == CoinSelectionStrategy.UpToAmount ? $"AND value < {amount}" : "";
 			// Added OrderBy to the query
 			var utxos = await conn.QueryAsync<(
 				long? blk_height,

--- a/NBXplorer/Properties/launchSettings.json
+++ b/NBXplorer/Properties/launchSettings.json
@@ -28,7 +28,6 @@
     "NBXplorer - Elenpay Dev": {
       "commandName": "Project",
       "commandLineArgs": "--chains=btc --network=regtest",
-      "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "NBXPLORER_EXPOSERPC": "true",

--- a/NBXplorer/Properties/launchSettings.json
+++ b/NBXplorer/Properties/launchSettings.json
@@ -37,7 +37,7 @@
         "NBXPLORER_BTCRPCPASSWORD": "polarpass",
         "NBXPLORER_BTCRPCURL": "http://localhost:18443/",
         "NBXPLORER_BTCNODEENDPOINT": "127.0.0.1:19444",
-        "NBXPLORER_BIND": "localhost:12838",
+        "NBXPLORER_BIND": "localhost:32838",
         "NBXPLORER_NOAUTH": 1
       },
       "applicationUrl": "http://localhost:4774"


### PR DESCRIPTION
Related to
https://github.com/Elenpay/NodeGuard/pull/289
and
https://github.com/Elenpay/btcpayserver/pull/52


The existing strategies cover the amount, because they are mostly used for opening channels. This new coin selection strategy `UpToAmount` selects utxos closer to the amount we want to use, but without going over it.

Added a way to ignore some outpoints, since we don't want the automatic selection to get utxos that are locked for other transactions

Also refactored a bit so we use an interface for coin selection and we can add more easily on the go.

TODO: get rid of the enum somehow