### PR TITLE
Allow selectutxos endpoint to work with DBTRIE

### DIFF
--- a/NBXplorer/Controllers/CoinSelectionController.cs
+++ b/NBXplorer/Controllers/CoinSelectionController.cs
@@ -46,7 +46,7 @@ namespace NBXplorer.Controllers
 		[HttpGet]
 		[Route("cryptos/{cryptoCode}/derivations/{derivationScheme}/selectutxos")]
 		[Route("cryptos/{cryptoCode}/addresses/{address}/selectutxos")]
-		[PostgresImplementationActionConstraint(true)]
+		[PostgresImplementationActionConstraint(false)]
 		public async Task<IActionResult> GetUTXOsByLimit(
 			string cryptoCode,
 			[ModelBinder(BinderType = typeof(DerivationStrategyModelBinder))]


### PR DESCRIPTION
For local development we use the DBTRIE database, but this endpoint was not working