### PR TITLE
Revert "Allow selectutxos endpoint to work with DBTRIE"

### DIFF
--- a/NBXplorer/Controllers/CoinSelectionController.cs
+++ b/NBXplorer/Controllers/CoinSelectionController.cs
@@ -46,7 +46,7 @@ namespace NBXplorer.Controllers
 		[HttpGet]
 		[Route("cryptos/{cryptoCode}/derivations/{derivationScheme}/selectutxos")]
 		[Route("cryptos/{cryptoCode}/addresses/{address}/selectutxos")]
-		[PostgresImplementationActionConstraint(false)]
+		[PostgresImplementationActionConstraint(true)]
 		public async Task<IActionResult> GetUTXOsByLimit(
 			string cryptoCode,
 			[ModelBinder(BinderType = typeof(DerivationStrategyModelBinder))]


### PR DESCRIPTION
Reverts Elenpay/NBXplorer#3

I say we revert this until we can work on a solution. Bug documented here: https://www.notion.so/clovrlabs/GetUtxosByLimit-not-working-on-either-dbtrie-or-postgres-9058b2c8c53d42868b0bb48d3d117ad1?pvs=4